### PR TITLE
Add Dockerfile and README for pdf2htmlEX on Ubuntu 24.04

### DIFF
--- a/docker/pdf2HtmlEx/ubuntu-24.04/Dockerfile
+++ b/docker/pdf2HtmlEx/ubuntu-24.04/Dockerfile
@@ -1,0 +1,35 @@
+FROM pdf2htmlex/pdf2htmlex:0.18.8.rc2-master-20200820-ubuntu-20.04-x86_64 AS pdf2htmlex-libs
+
+RUN mkdir -p /download/x86_64-linux-gnu/ \
+    && cp /usr/lib/x86_64-linux-gnu/libcairo.so.2 /download/x86_64-linux-gnu \
+    && cp /usr/lib/x86_64-linux-gnu/libjpeg.so.8 /download/x86_64-linux-gnu \
+    && cp /usr/lib/x86_64-linux-gnu/libpng16.so.16 /download/x86_64-linux-gnu \
+    && cp /usr/lib/x86_64-linux-gnu/libfontconfig.so.1 /download/x86_64-linux-gnu \
+    && cp /usr/lib/x86_64-linux-gnu/libfreetype.so.6 /download/x86_64-linux-gnu \
+    && cp /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0 /download/x86_64-linux-gnu \
+    && cp /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0 /download/x86_64-linux-gnu \
+    && cp /usr/lib/x86_64-linux-gnu/libxcb-shm.so.0 /download/x86_64-linux-gnu \
+    && cp /usr/lib/x86_64-linux-gnu/libxcb.so.1 /download/x86_64-linux-gnu \
+    && cp /usr/lib/x86_64-linux-gnu/libxcb-render.so.0 /download/x86_64-linux-gnu \
+    && cp /usr/lib/x86_64-linux-gnu/libXrender.so.1 /download/x86_64-linux-gnu \
+    && cp /usr/lib/x86_64-linux-gnu/libX11.so.6 /download/x86_64-linux-gnu \
+    && cp /usr/lib/x86_64-linux-gnu/libXext.so.6 /download/x86_64-linux-gnu \
+    && cp /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0 /download/x86_64-linux-gnu \
+    && cp /usr/lib/x86_64-linux-gnu/libgmodule-2.0.so.0 /download/x86_64-linux-gnu \
+    && cp /usr/lib/x86_64-linux-gnu/libXau.so.6 /download/x86_64-linux-gnu \
+    && cp /usr/lib/x86_64-linux-gnu/libXdmcp.so.6 /download/x86_64-linux-gnu \
+    && cp /usr/lib/x86_64-linux-gnu/libpixman-1.so.0 /download/x86_64-linux-gnu \
+    && cp /usr/lib/x86_64-linux-gnu/libpcre.so.3 /download/x86_64-linux-gnu \
+    && cp /usr/lib/x86_64-linux-gnu/libffi.so.7 /download/x86_64-linux-gnu
+
+FROM wayoyo/python:latest
+
+LABEL maintainer="Wayoyo Digital <dfproffesional@gmail.com>"
+LABEL org.opencontainers.image.title="pdf2htmlEX Python Dev"
+LABEL org.opencontainers.image.description="Ubuntu 24.04 image with pdf2htmlEX and Python dev tools"
+LABEL org.opencontainers.image.source="https://github.com/Wayoyo-Digital/Dockerfile"
+
+COPY --from=pdf2htmlex-libs /usr/local/bin/pdf2htmlEX /usr/local/bin/pdf2htmlEX
+COPY --from=pdf2htmlex-libs /usr/local/share/pdf2htmlEX /usr/local/share/pdf2htmlEX
+COPY --from=pdf2htmlex-libs /download/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu
+

--- a/docker/pdf2HtmlEx/ubuntu-24.04/README.MD
+++ b/docker/pdf2HtmlEx/ubuntu-24.04/README.MD
@@ -1,0 +1,60 @@
+# Explanation of the pdf2HtmlEx Dockerfile for Ubuntu 24.04
+
+This Dockerfile creates a container image that includes the `pdf2htmlEX` utility on top of an Ubuntu 24.04-based Python environment. The image is designed not only for PDF to HTML conversion, but also as a development container for Python projects using frameworks like Flask or FastAPI.
+
+## Dockerfile Overview
+
+### 1. Multi-Stage Build
+
+- **Stage 1:**  
+  Starts from `pdf2htmlex/pdf2htmlex:0.18.8.rc2-master-20200820-ubuntu-20.04-x86_64`.  
+  In this stage, all the required shared libraries for `pdf2htmlEX` are copied into a temporary directory. This ensures that all dependencies are available for the final image.
+
+- **Stage 2:**  
+  Uses `wayoyo/python:latest` as the base image, which is suitable for Python development.  
+  The `pdf2htmlEX` binary, its resources, and the previously extracted libraries are copied into their appropriate locations in the new image.
+
+### 2. Python Development Ready
+
+The final image is based on a Python environment, making it ideal for developing and running Python applications. You can easily install Flask, FastAPI, or other Python frameworks and libraries as needed.
+
+### 3. Use Cases
+
+- **PDF to HTML Conversion:**  
+  Use the included `pdf2htmlEX` tool to convert PDF documents to HTML format.
+
+- **Python Web Development:**  
+  The image is ready for development with Python web frameworks such as Flask or FastAPI. This makes it suitable for building web APIs or applications that process or serve converted HTML content.
+
+### 4. How It Works
+
+- Extracts all necessary libraries from the original `pdf2htmlEX` image to ensure compatibility.
+- Copies the `pdf2htmlEX` binary and its resources to the new image.
+- Provides a Python environment for further development.
+
+### 5. Getting Started
+
+To use this container for development:
+
+1. **Build the image:**
+   ```
+   docker build -t pdf2htmlex-dev .
+   ```
+
+2. **Run the container with your project:**
+   ```
+   docker run -it -v $(pwd):/app pdf2htmlex-dev bash
+   ```
+
+3. **Install Flask or FastAPI as needed:**
+   ```
+   pip install flask fastapi uvicorn
+   ```
+
+4. **Develop your Python application using Flask or FastAPI, and use `pdf2htmlEX` as needed within your code or scripts.**
+
+---
+
+This container is ideal for developers who need both PDF to HTML conversion capabilities and a modern Python development environment, especially for building web services or APIs with Flask or FastAPI.
+
+


### PR DESCRIPTION
This commit introduces a new Dockerfile that sets up a multi-stage build for the pdf2htmlEX utility, incorporating necessary libraries and a Python development environment. The accompanying README provides an overview of the Dockerfile, usage instructions, and highlights the container's suitability for both PDF to HTML conversion and Python web development.